### PR TITLE
fix: $years for filter options was a 2d array, needed array of strings

### DIFF
--- a/app/Livewire/Home.php
+++ b/app/Livewire/Home.php
@@ -36,7 +36,12 @@ class Home extends Component
         $this->user = $user;
 
         $this->trialBalances = TrialBalance::orderBy('created_at', 'desc')->take(6)->get();
-        $years = FinancialStatementCollection::select('fsc_year')->orderBy('fsc_year', 'desc')->get()->toArray();
+        $years = array_unique(
+            array_column(
+                FinancialStatementCollection::select('fsc_year')->orderBy('fsc_year', 'desc')->get()->toArray(),
+                'fsc_year',
+            )
+        );
 
         if (!$years) {
             $years = [date('Y')];

--- a/database/migrations/2023_11_19_060122_tb_data_history.php
+++ b/database/migrations/2023_11_19_060122_tb_data_history.php
@@ -30,7 +30,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('tb_data_history');
+        Schema::dropIfExists('trial_balance_histories');
     }
 };
-


### PR DESCRIPTION
homepage bug. blade was trying to put arrays as value in html attributes. now properly fixed filter options to have an array of strings instead of a 2d array